### PR TITLE
fix turtle syntax errors

### DIFF
--- a/api-documentation/2.3.complete-api-documentation.md
+++ b/api-documentation/2.3.complete-api-documentation.md
@@ -40,7 +40,7 @@ Example of such a description may be as follows (in Turtle syntax):
     hydra:entrypoint </> ;
     hydra:title "Hydra example API." ;
     hydra:description "Some example API described using Hydra vocabulary" ;
-    hydra:supportedClass schema:Event, schema:Person ;
+    hydra:supportedClass schema:Event, schema:Person .
 
 schema:Event a hydra:Class ;
     hydra:supportedOperation <#get-events-operation> ,
@@ -91,13 +91,13 @@ schema:Event a hydra:Class ;
 
 <#get-events-operation> a hydra:Operation ;
    hydra:method "GET"^^xsd:string ;
-   hydra:possibleStatus "200"^xsd:int, "500"^^xsd:int ;
+   hydra:possibleStatus "200"^^xsd:int, "500"^^xsd:int ;
    hydra:returns hydra:Collection .
 
 <#new-event-operation> a hydra:Operation, schema:CreateAction ;
     hydra:expects schema:Event ;
-    hydra:method "POST"^^xsd:string
-    hydra:possibleStatus "200"^xsd:int, "500"^^xsd:int .
+    hydra:method "POST"^^xsd:string ;
+    hydra:possibleStatus "200"^^xsd:int, "500"^^xsd:int .
 
 # Link with operation below does not mention directly that no value is returned.
 # Only hint of that may be taken from the 201 status.
@@ -111,19 +111,19 @@ schema:Event a hydra:Class ;
         a hydra:Operation, schema:UpdateAction ;
         hydra:title "Updates an event." ;
         hydra:method "PUT"^^xsd:string ;
-        hydra:possibleStatus "201"^xsd:int, "404"^^xsd:int, "500"^^xsd:int ;
+        hydra:possibleStatus "201"^^xsd:int, "404"^^xsd:int, "500"^^xsd:int ;
         hydra:expects schema:Event
     ], [
         a hydra:Operation, schema:DeleteAction ;
         hydra:title "Deletes an event." ;
         hydra:method "DELETE"^^xsd:string ;
-        hydra:possibleStatus "201"^xsd:int, "404"^^xsd:int, "500"^^xsd:int
+        hydra:possibleStatus "201"^^xsd:int, "404"^^xsd:int, "500"^^xsd:int
     ].
 
 <#id-mapping> a hydra:IriTemplateMapping ;
     hydra:variableRepresentation: hydra:BasicRepresentation ;
     hydra:variable "id"^^xsd:string ;
-    hydra:property vocab:id ;
+    hydra:property vocab:id .
 
 vocab:id a rdf:Property ;
     rdf:domain schema:Event ;


### PR DESCRIPTION
#251 On http://cookbook.hydra-cg.com/api-documentation/2.3.complete-api-documentation the turtle document has syntax issues. This Patch fixes them.